### PR TITLE
Fixed crash on Symmetrize Shape, shapes_list wrong display and a lot of optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@
 - [ ] Fix the errors when bones are sharing data (in a rig that already has widgets)
 
 ## v1.7 Release Notes
-* Fixed symmetrizeWidget (was crashing because of assigning name to None object, removed multiple redundent calls of the findMirrorObject)
+* Fixed symmetrizeWidget (was crashing because of assigning name to None object, removed multiple redundant calls of the findMirrorObject)
 * Optimized addRemoveWidgets (now it doesn't overwrites library if a widget with the same name already exists in the library)
 * Optimized BONEWIDGET_OT_matchSymmetrizeShape
 * Optimized BONEWIDGET_OT_addWidgets
 * Changed prefs from WDGT_ and WDGT_shapes to WGT_...
-* Fixed wrong displaying of shapes list after adding/deleting them to/from library. If a new widget has beed added to the library, it becomes selected and displays in the
-  shapes list. If a widget has beed removed from the library, a first element from the list will be selected.
+* Fixed wrong displaying of shapes list after adding/deleting them to/from library. If a new widget has been added to the library, it becomes selected and displays in the
+  shapes list. If a widget has been removed from the library, a first element from the list will be selected.
 
 ## v1.6 Release Notes
 * Fixed the "DELETE UNUSED WIDGETS" function (was crashing because the context was wrong)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@
 - [ ] Update the video explanation
 - [ ] Fix the errors when bones are sharing data (in a rig that already has widgets)
 
+## v1.7 Release Notes
+* Fixed symmetrizeWidget (was crashing because of assigning name to None object, removed multiple redundent calls of the findMirrorObject)
+* Optimized addRemoveWidgets (now it doesn't overwrites library if a widget with the same name already exists in the library)
+* Optimized BONEWIDGET_OT_matchSymmetrizeShape
+* Optimized BONEWIDGET_OT_addWidgets
+* Changed prefs from WDGT_ and WDGT_shapes to WGT_...
+* Fixed wrong displaying of shapes list after adding/deleting them to/from library. If a new widget has beed added to the library, it becomes selected and displays in the
+  shapes list. If a widget has beed removed from the library, a first element from the list will be selected.
+
 ## v1.6 Release Notes
 * Fixed the "DELETE UNUSED WIDGETS" function (was crashing because the context was wrong)
 

--- a/__init__.py
+++ b/__init__.py
@@ -20,8 +20,8 @@ Created by Manuel Rais and Christophe Seux
 
 bl_info = {
     "name": "Bone Widget",
-    "author": "Manuel Rais, Christophe Seux, Bassam Kurdali, Wayne Dixon",
-    "version": (1, 6),
+    "author": "Manuel Rais, Christophe Seux, Bassam Kurdali, Wayne Dixon, Max Nadolny",
+    "version": (1, 7),
     "blender": (2, 80, 0),
     "location": "UI > Properties Panel",
     "description": "Easily Create Bone Widgets",

--- a/functions/mainFunctions.py
+++ b/functions/mainFunctions.py
@@ -114,14 +114,13 @@ def symmetrizeWidget(bone, collection):
 
     widget = bone.custom_shape
 
-    if findMirrorObject(bone).custom_shape_transform:
-        mirrorBone = findMirrorObject(bone).custom_shape_transform
-    else:
-        mirrorBone = findMirrorObject(bone)
+    mirrorBone = findMirrorObject(bone)
+    if mirrorBone.custom_shape_transform:
+        mirrorBone = mirrorBone.custom_shape_transform
 
     mirrorWidget = mirrorBone.custom_shape
 
-    if mirrorWidget != widget:
+    if mirrorWidget is not None and mirrorWidget != widget:
         mirrorWidget.name = mirrorWidget.name+"_old"
         mirrorWidget.data.name = mirrorWidget.data.name+"_old"
         # unlink/delete old widget
@@ -225,7 +224,7 @@ def findMirrorObject(object):
     elif object.name.endswith("r"):
         suffix = 'l'
     else:  # what if the widget ends in .001?
-        print('Object suffix unknown using blank')
+        print('Object suffix unknown, using blank')
         suffix = ''
 
     objectName = list(object.name)
@@ -246,7 +245,7 @@ def findMatchBones():
 
     if bpy.context.object.type == 'ARMATURE':
         for bone in C.selected_pose_bones:
-            if bone.name.endswith("L") or bone.name.endswith("R"):
+            if bone.name.endswith(("L","R")):
                 widgetsAndBones[bone] = bone.custom_shape
                 mirrorBone = findMirrorObject(bone)
                 if mirrorBone:
@@ -257,7 +256,7 @@ def findMatchBones():
     else:
         for shape in C.selected_objects:
             bone = fromWidgetFindBone(shape)
-            if bone.name.endswith("L") or bone.name.endswith("R"):
+            if bone.name.endswith(("L","R")):
                 widgetsAndBones[fromWidgetFindBone(shape)] = shape
 
                 mirrorShape = findMirrorObject(shape)

--- a/operators.py
+++ b/operators.py
@@ -150,20 +150,16 @@ class BONEWIDGET_OT_matchSymmetrizeShape(bpy.types.Operator):
 
     def execute(self, context):
         collection = getCollection(context)
-        widgetsAndBones = findMatchBones()[0]
-        activeObject = findMatchBones()[1]
-        widgetsAndBones = findMatchBones()[0]
+        widgetsAndBones, activeObject, armature = findMatchBones()
 
         if not activeObject:
             self.report({"INFO"}, "No active bone or object")
             return {'FINISHED'}
 
+        if activeObject.name.endswith(("L","R")):
+            suffix = activeObject.name.rsplit(".", 1)[1]
         for bone in widgetsAndBones:
-            if activeObject.name.endswith("L"):
-                if bone.name.endswith("L") and widgetsAndBones[bone]:
-                    symmetrizeWidget(bone, collection)
-            elif activeObject.name.endswith("R"):
-                if bone.name.endswith("R") and widgetsAndBones[bone]:
+                if bone.name.endswith(suffix) and widgetsAndBones[bone]:
                     symmetrizeWidget(bone, collection)
 
         return {'FINISHED'}
@@ -186,8 +182,10 @@ class BONEWIDGET_OT_addWidgets(bpy.types.Operator):
 
         if not objects:
             self.report({'INFO'}, 'Select Meshes or Pose_bones')
-
-        addRemoveWidgets(context, "add", bpy.types.Scene.widget_list[1]['items'], objects)
+        else:
+            ret = addRemoveWidgets(context, "add", bpy.types.Scene.widget_list[1]['items'], objects)
+            if ret:
+                self.report({'WARNING'}, ret)
 
         return {'FINISHED'}
 
@@ -219,7 +217,7 @@ class BONEWIDGET_OT_toggleCollectionVisibility(bpy.types.Operator):
 
 
 class BONEWIDGET_OT_deleteUnusedWidgets(bpy.types.Operator):
-    """Delete unused objects in the WDGT collection"""
+    """Delete unused objects in the WGT collection"""
     bl_idname = "bonewidget.delete_unused_widgets"
     bl_label = "Delete Unused Widgets"
 

--- a/panels.py
+++ b/panels.py
@@ -22,7 +22,7 @@ class BONEWIDGET_PT_posemode_panel(bpy.types.Panel):
         itemsSort.append((key, key, ""))
 
     bpy.types.Scene.widget_list = bpy.props.EnumProperty(
-        name="Shape", items=itemsSort, description="Shape")
+        items=itemsSort, name="Shape", description="Shape")
 
     def draw(self, context):
         layout = self.layout

--- a/prefs.py
+++ b/prefs.py
@@ -10,7 +10,7 @@ class BoneWidgetPreferences(AddonPreferences):
     widget_prefix: StringProperty(
         name="Bone Widget prefix",
         description="Choose a prefix for the widget objects",
-        default="WDGT_",
+        default="WGT_",
     )
     '''
     #symmetry suffix (will try to implement this later)
@@ -24,7 +24,7 @@ class BoneWidgetPreferences(AddonPreferences):
     bonewidget_collection_name: StringProperty(
         name="Bone Widget collection name",
         description="Choose a name for the collection the widgets will appear",
-        default="WDGT_shapes",
+        default="WGT_shapes",
     )
 
     def draw(self, context):


### PR DESCRIPTION
* Fixed symmetrizeWidget (was crashing because of assigning name to None object, removed multiple redundant calls of the findMirrorObject)
* Optimized addRemoveWidgets (now it doesn't overwrites library if a widget with the same name already exists in the library)
* Optimized BONEWIDGET_OT_matchSymmetrizeShape
* Optimized BONEWIDGET_OT_addWidgets
* Changed prefs from WDGT_ and WDGT_shapes to WGT_...
* Fixed wrong displaying of shapes list after adding/deleting them to/from library. If a new widget has been added to the library, it becomes selected and displays in the shapes list. If a widget has been removed from the library, a first element from the list will be selected.